### PR TITLE
feat(HACBS-2310): add RoleBindings for Release ClusterRole

### DIFF
--- a/fbc/release/managed-workspace/role_binding.yaml
+++ b/fbc/release/managed-workspace/role_binding.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-service-pipeline-rolebinding-dev
+  namespace: user1-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: managed-release-team-tenant
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-service-pipeline-rolebinding-managed
+  namespace: managed-release-team-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: managed-release-team-tenant

--- a/mvp/release/managed-workspace/admin/kustomization.yaml
+++ b/mvp/release/managed-workspace/admin/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - persistent_volume_claim.yaml
+  - role_binding.yaml
   #- service_account.yaml
   #- secret-role.yaml
   # no longer needed after

--- a/mvp/release/managed-workspace/admin/role_binding.yaml
+++ b/mvp/release/managed-workspace/admin/role_binding.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-service-pipeline-rolebinding-dev
+  namespace: dev-release-team-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: managed-release-team-tenant
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: release-service-pipeline-rolebinding-managed
+  namespace: managed-release-team-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-resource-role
+subjects:
+- kind: ServiceAccount
+  name: release-service-account
+  namespace: managed-release-team-tenant


### PR DESCRIPTION
A new ClusterRole was created within the Release Service to allow the Release PipelineRuns to access Custom Resources in the dev and managed namespaces. This commit adds RoleBindings for it.